### PR TITLE
Adding login credentials and guide how to fix `can only be default-imported...` message to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The project is a standard Maven project, so you can import it to your IDE of cho
 
 To run from the command line, use `mvn` and open [http://localhost:8080](http://localhost:8080) in your browser.
 
+You can login with the following credentials:
+- user/user with role USER
+- admin/admin with role ADMIN
+
 ## This application is demoing various aspects of Hilla framework
 
 - Lazy loading data from server

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ The project is a standard Maven project, so you can import it to your IDE of cho
 
 To run from the command line, use `mvn` and open [http://localhost:8080](http://localhost:8080) in your browser.
 
-You can login with the following credentials:
+You can log in with the following credentials:
 - user/user with role USER
 - admin/admin with role ADMIN
 
 ## This application is demoing various aspects of Hilla framework
 
 - Lazy loading data from server
-- Using server side filterign of data
-- Securing statelss Hilla app using Spring Security
+- Using server side filtering of data
+- Securing stateless Hilla app using Spring Security
 - Demonstrating role based authorities, method level end point security
 - Styling using Lumo utility classes
 - Handling url parameters of the route
@@ -73,6 +73,30 @@ mvn spring-boot:run
 | `src/`                                     | Server-side source directory                                                                                           |
 | &nbsp;&nbsp;&nbsp;&nbsp;`Application.java` | Server entrypoint                                                                                          |
 | &nbsp;&nbsp;&nbsp;&nbsp; `data/`            | Entities and endpoints directory (Java)                                                                                              |
+
+## Exception:
+- If you have this error:
+
+```[TypeScript] Module '"/Users/pczuczor/Projects/hilla-demo/node_modules/.pnpm/@types+cleave.js@1.4.7/node_modules/@types/cleave.js/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+4 | import { ifDefined } from "lit-html/directives/if-defined.js";
+5 | import { customElement, property, query } from "lit/decorators.js";
+> 6 | import Cleave from "cleave.js";
+|        ^^^^^^
+7 | import { CleaveOptions } from "cleave.js/options";
+```
+Or here:
+```
+import { uiStore } from './stores/app-store';
+```
+
+- Then please add `"allowSyntheticDefaultImports": true` to your tsconfig.json `compilerOptions` part (in your project root)
+```
+"compilerOptions": {
+  "allowSyntheticDefaultImports": true,
+  ...
+  }
+```
+
 
 ## What next?
 

--- a/src/main/java/com/example/application/security/SecurityConfig.java
+++ b/src/main/java/com/example/application/security/SecurityConfig.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.spring.security.VaadinWebSecurity;
 @Configuration
 public class SecurityConfig extends VaadinWebSecurity {
 
-    // create file "config/secrests/application.properties"
+    // create file "config/secrets/application.properties"
     // use this command to generate new random secret for your app:
     // openssl rand -base64 32
     @Value("${com.example.application.app.secret}")


### PR DESCRIPTION
Changes:
-  Adding a note on how to fix potential `can only be default-imported using the ...` error, exception for the app.
-   Adding needed credentials for login to README.md (before that it was only possible to get from the code with search, this can spare some time for the ones cloning it)
- small typo fix in `SecurityConfig.java`